### PR TITLE
Use HTTPS for assets

### DIFF
--- a/resources/views/core/footer.blade.php
+++ b/resources/views/core/footer.blade.php
@@ -2,14 +2,14 @@
         <footer style="margin-top: 50px;">
         </footer>
     </body>
-    <script src="http://code.jquery.com/jquery-2.1.4.min.js"></script>
+    <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script src="/js/typed.min.js"></script>
     <script src="/js/validator.js"></script>
     <script src="/js/sweetalert.min.js"></script>
     <script src="//cdn.datatables.net/1.10.7/js/jquery.dataTables.min.js"></script>
     <script src="//cdn.datatables.net/plug-ins/1.10.7/integration/bootstrap/3/dataTables.bootstrap.js"></script>
-    <script src="http://code.highcharts.com/highcharts.js"></script>
+    <script src="https://code.highcharts.com/highcharts.js"></script>
     <script src="/packages/pickadate/picker.js"></script>
     <script src="/packages/pickadate/picker.date.js"></script>
     <script src="/packages/pickadate/picker.time.js"></script>


### PR DESCRIPTION
Use HTTPS for assets over HTTP when loading page either via HTTP or HTTPS. 

Signed-off-by: Colin Schoen <cschoen@berkeley.edu>