### PR TITLE
Support Module Specific URLs in TA Console

### DIFF
--- a/app/Http/Controllers/TAController.php
+++ b/app/Http/Controllers/TAController.php
@@ -152,7 +152,7 @@ class TAController extends Controller {
         $p = Password::where('gsi', '=', Auth::user()->id)->first();
         $p->password = $password;
         $p->save();
-        return redirect()->route("taconsole")->with("message", "You have successfully updated your secret word");
+        return redirect()->route("taconsole", "secretWord")->with("message", "You have successfully updated your secret word");
     }
 
     public function post_edit_checkin_user() {
@@ -200,7 +200,7 @@ class TAController extends Controller {
         $checkin->save();
         //Make an audit log entry for this checkin
         Audit::log("GSI " . Auth::user()->name . " edited existing checked in for " . $checkin->user->name);
-        return redirect()->route("taconsole")->with("message", "Editing check in for " . $checkin->user->name . " was successful.");
+        return redirect()->route("taconsole", "checkins")->with("message", "Editing check in for " . $checkin->user->name . " was successful.");
     }
 
     public function post_checkin_user() {
@@ -247,7 +247,7 @@ class TAController extends Controller {
         $checkin->save();
         //Make an audit log entry for this checkin
         Audit::log("GSI " . Auth::user()->name . " manually checked in " . $user->name);
-        return redirect()->route("taconsole")->with("message", "Manual check in for " . $user->name . " was successful.");
+        return redirect()->route("taconsole", "users")->with("message", "Manual check in for " . $user->name . " was successful.");
     }
 
     public function post_checkin_remove($id) {
@@ -258,7 +258,7 @@ class TAController extends Controller {
         //Make an audit notation
         Audit::log(Auth::user()->name . " manually removed check in for " . $checkin->user->name);
         //Return our redirect
-        return redirect()->route("taconsole")->with("message", "Check in for " . $checkin->user->name . " successfully manually removed.");
+        return redirect()->route("taconsole", "checkins")->with("message", "Check in for " . $checkin->user->name . " successfully manually removed.");
     }
 
     public function get_user_promote_tutor($id) {
@@ -276,7 +276,7 @@ class TAController extends Controller {
         $password->password = "recursion";
         $password->save();
         //Let them know all is ok
-        return redirect()->route("taconsole")->with("message", $user->name . " successfully promoted from Lab Assistant to Tutor.");
+        return redirect()->route("taconsole", "users")->with("message", $user->name . " successfully promoted from Lab Assistant to Tutor.");
     }
 
     public function get_user_promote($id) {
@@ -294,7 +294,7 @@ class TAController extends Controller {
         $password->password = "recursion";
         $password->save();
         //Let them know all is ok
-        return redirect()->route("taconsole")->with("message", $user->name . " successfully promoted to GSI.");
+        return redirect()->route("taconsole", "users")->with("message", $user->name . " successfully promoted to GSI.");
     }
 
     public function get_user_demote($id) {
@@ -310,7 +310,7 @@ class TAController extends Controller {
         $password = Password::where("gsi", "=", $user->id)->first();
         $password->delete();
         //Let them know all is ok
-        return redirect()->route("taconsole")->with("message", $user->name . " successfully demoted to Lab Assistant.");
+        return redirect()->route("taconsole", "users")->with("message", $user->name . " successfully demoted to Lab Assistant.");
     }
 
     public function post_update_type() {
@@ -329,9 +329,9 @@ class TAController extends Controller {
         //Ensure that the member set a name for the new event type and that it does not match another type
         $otherType = Type::where("name", "=", $name)->count();
         if ($otherType > 1 || $name == "")
-            return redirect()->route("taconsole")->with("message", "Either your type was empty or you entered an existing type.");
+            return redirect()->route("taconsole", "eventTypes")->with("message", "Either your type was empty or you entered an existing type.");
         if (!is_numeric($hours)) {
-            return redirect()->route("taconsole")->with("message", "Ensure you are entering a numeric value for hours in your event type.");
+            return redirect()->route("taconsole", "eventTypes")->with("message", "Ensure you are entering a numeric value for hours in your event type.");
         }
         //Alright all good let's update the model
         $type->name = $name;
@@ -340,7 +340,7 @@ class TAController extends Controller {
         //And finally the DB
         $type->save();
         //Let the user know things are well :)
-        return redirect()->route("taconsole")->with("message", "The " . $name . " type was updated successfully");
+        return redirect()->route("taconsole", "eventTypes")->with("message", "The " . $name . " type was updated successfully");
     }
 
 
@@ -353,9 +353,9 @@ class TAController extends Controller {
             $hidden = 0;
         $otherTypes = Type::where("name", "=", $name)->count();
         if ($otherTypes > 0 ||$name == "")
-            return redirect()->route("taconsole")->with("message", "Either your new event type is empty or an existing event type exists with the same name.");
+            return redirect()->route("taconsole", "eventTypes")->with("message", "Either your new event type is empty or an existing event type exists with the same name.");
         if (!is_numeric($hours)) {
-            return redirect()->route("taconsole")->with("message", "Ensure you are entering a numeric value for hours in your new event type.");
+            return redirect()->route("taconsole", "eventTypes")->with("message", "Ensure you are entering a numeric value for hours in your new event type.");
         }
         //Create our model
         $type = new Type;
@@ -365,7 +365,7 @@ class TAController extends Controller {
         //Push the model to the DB
         $type->save();
         //Alert the user
-        return redirect()->route("taconsole")->with("message", "Your new event type was created successfully.");
+        return redirect()->route("taconsole", "eventTypes")->with("message", "Your new event type was created successfully.");
     }
 
     public function get_download_checkins() {
@@ -424,7 +424,7 @@ class TAController extends Controller {
         $announcement->hidden = 0;
         $announcement->save();
         //Redirect back to the ta console
-        return redirect()->route('taconsole')->with("message", "Your announcement was created. To make it public please change its visibility status.");
+        return redirect()->route('taconsole', "announcments")->with("message", "Your announcement was created. To make it public please change its visibility status.");
     }
 
     public function get_announcement_visibility($id) {
@@ -435,14 +435,14 @@ class TAController extends Controller {
             $announcement->hidden = 0;
         //Save our announcement
         $announcement->save();
-        return redirect()->route('taconsole')->with("message", "The announcement visibility was updated successfully");
+        return redirect()->route('taconsole', "announcements")->with("message", "The announcement visibility was updated successfully");
     }
 
     public function get_announcement_delete($id) {
         $announcement = Announcement::findOrFail($id);
         //Delete it
         $announcement->delete();
-        return redirect()->route('taconsole')->with("message", "The announcement was deleted successfully");
+        return redirect()->route('taconsole', "announcements")->with("message", "The announcement was deleted successfully");
     }
 
     public function post_section_import() {
@@ -632,7 +632,7 @@ class TAController extends Controller {
             $section->save();
         }
 
-        return redirect()->route("taconsole")->with("message", "Imported " . $count . " sections.");
+        return redirect()->route("taconsole", "sections")->with("message", "Imported " . $count . " sections.");
 
     }
     
@@ -787,7 +787,7 @@ class TAController extends Controller {
         //Push to the DB
         $section->save();
         //Return a redirect Response
-        return redirect()->route("taconsole")->with("message", "The new section was successfully created.");
+        return redirect()->route("taconsole", "sections")->with("message", "The new section was successfully created.");
     }
 
     public function get_section_delete($sid) {
@@ -796,7 +796,7 @@ class TAController extends Controller {
         $preferences = Preference::where('section', '=', $sid)->delete();
         //Delete the section
         $section->delete();
-        return redirect()->route("taconsole")->with("message", "The section was successfully deleted.");
+        return redirect()->route("taconsole", "sections")->with("message", "The section was successfully deleted.");
     }
     public function post_section_addla() {
         $section = Section::findOrFail(Request::input('inputSection'));
@@ -808,7 +808,7 @@ class TAController extends Controller {
         $assignment->save();
         //Log this
         Audit::log("Assigned " . $user->name . " to section id " . $section->id);
-        return redirect()->route("taconsole")->with("message", $user->name . " successfully added to section.");
+        return redirect()->route("taconsole", "sections")->with("message", $user->name . " successfully added to section.");
     }
     public function post_section_edit() {
         //Get all of our data
@@ -924,7 +924,7 @@ class TAController extends Controller {
         }
         //Route our validator
         if ($validator->fails()) {
-            return redirect()->route('taconsole')->withErrors($validator);
+            return redirect()->route('taconsole', "sections")->withErrors($validator);
         }
         //Create a new instance of our Section model
         $section = Section::findOrFail($sid);
@@ -970,7 +970,7 @@ class TAController extends Controller {
         //Push to the DB
         $section->save();
         //Return a redirect Response
-        return redirect()->route("taconsole")->with("message", "The section was edited successfully.");
+        return redirect()->route("taconsole", "sections")->with("message", "The section was edited successfully.");
     }
     
 
@@ -1008,7 +1008,7 @@ class TAController extends Controller {
         }
         $informationContent = Request::input('inputInformationContent');
         Setting::change("information_content", $informationContent);
-        return redirect()->route("taconsole")->with("message", "The settings were saved successfully.");
+        return redirect()->route("taconsole", "settings")->with("message", "The settings were saved successfully.");
     }
 
     public function post_feedback_add() {
@@ -1021,7 +1021,7 @@ class TAController extends Controller {
         $feedback->gsi = Auth::user()->id;
         $feedback->comment = $comment;
         $feedback->save();
-        return redirect()->route("taconsole")->with("message", "Feedback successfully saved.");
+        return redirect()->route("taconsole", "users")->with("message", "Feedback successfully saved.");
     }
 
 }

--- a/app/Http/Controllers/TAController.php
+++ b/app/Http/Controllers/TAController.php
@@ -20,8 +20,8 @@ class TAController extends Controller {
         $announcements = Announcement::where("hidden", "!=", 0)->orderBy("created_at", "DESC")->get();
         View::share('announcements', $announcements);
     }
-    public function get_console() {
-        return view("ta.console");
+    public function get_console($module = "users") {
+        return view("ta.console")->with(["module" => $module]);
     }
 
     public function get_module_users() {

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -46,7 +46,7 @@
 
 //TA/Tutor Routes
     //GET
-    Route::get('ta/console', ["as" => "taconsole", "uses" => "TAController@get_console", "middleware" => "auth.tutor"]);
+    Route::get('ta/console/{module?}', ["as" => "taconsole", "uses" => "TAController@get_console", "middleware" => "auth.tutor"]);
     Route::get('ta/download/checkins', ["as" => "tadownloadcheckins", "uses" => "TAController@get_download_checkins", "middleware" => "auth.tutor"]);
     Route::get('ta/download/roster', ["as" => "tadownloadroster", "uses" => "TAController@get_download_roster", "middleware" => "auth.tutor"]);
     Route::get('ta/user/promote/{id}', ["as" => "tauserpromote", "uses" => "TAController@get_user_promote", "middleware" => "auth.ta"]);

--- a/resources/views/ta/console.blade.php
+++ b/resources/views/ta/console.blade.php
@@ -10,50 +10,50 @@
     <div class="row" style="margin-top: 20px;">
         <div class="col-lg-2">
             <ul class="nav nav-pills nav-stacked">
-                <li class="active"><a href="#laSearchPanel" data-toggle="pill"><i class="fa fa-users fa-fw"></i> Users</a></li>
-                <li><a href="#laCheckInsPanel" data-toggle="pill"><i class="fa fa-list-ol fa-fw"></i> Check Ins</a></li>
-                <li><a href="#secretWordPanel" data-toggle="pill"><i class="fa fa-key fa-fw"></i> Secret Word</a></li>
-                <li><a href="#announcementsPanel" data-toggle="pill"><i class="fa fa-bullhorn fa-fw"></i> Announcements</a></li>
-                <li><a href="#exportDataPanel" data-toggle="pill"><i class="fa fa-download fa-fw"></i> Export Data</a></li>
+                <li><a href="#usersModule" data-toggle="pill"><i class="fa fa-users fa-fw"></i> Users</a></li>
+                <li><a href="#checkinsModule" data-toggle="pill"><i class="fa fa-list-ol fa-fw"></i> Check Ins</a></li>
+                <li><a href="#secretWordModule" data-toggle="pill"><i class="fa fa-key fa-fw"></i> Secret Word</a></li>
+                <li><a href="#announcementsModule" data-toggle="pill"><i class="fa fa-bullhorn fa-fw"></i> Announcements</a></li>
+                <li><a href="#exportDataModule" data-toggle="pill"><i class="fa fa-download fa-fw"></i> Export Data</a></li>
                 @if (Auth::user()->is_gsi())
-                <li><a href="#sectionPanel" data-toggle="pill"><i class="fa fa-calendar fa-fw"></i> Sections</a></li>
-                <li><a href="#statsPanel" data-toggle="pill"><i class="fa fa-bar-chart fa-fw"></i> Statistics</a></li>
-                <li><a href="#eventTypesPanel" data-toggle="pill"><i class="fa fa-tags fa-fw"></i> Event Types</a></li>
-                <li><a href="#auditLogPanel" data-toggle="pill"><i class="fa fa-history fa-fw"></i> Audit Log</a></li>
-                <li><a href="#settingsPanel" data-toggle="pill"><i class="fa fa-cogs fa-fw"></i> Settings</a></li>
+                <li><a href="#sectionsModule" data-toggle="pill"><i class="fa fa-calendar fa-fw"></i> Sections</a></li>
+                <li><a href="#statsModule" data-toggle="pill"><i class="fa fa-bar-chart fa-fw"></i> Statistics</a></li>
+                <li><a href="#eventTypesModule" data-toggle="pill"><i class="fa fa-tags fa-fw"></i> Event Types</a></li>
+                <li><a href="#auditLogModule" data-toggle="pill"><i class="fa fa-history fa-fw"></i> Audit Log</a></li>
+                <li><a href="#settingsModule" data-toggle="pill"><i class="fa fa-cogs fa-fw"></i> Settings</a></li>
                 @endif
             </ul>
         </div>
         <div class="tab-content">
-            <div id="laSearchPanel" class="col-lg-10 tab-pane fade in active" data-target="{{ route("tamoduleusers") }}">
+            <div id="usersModule" class="col-lg-10 tab-pane fade in" data-target="{{ route("tamoduleusers") }}">
                 @include('ta.core.loading')
             </div>
-            <div id="laCheckInsPanel" class="col-lg-10 tab-pane fade" data-target="{{ route("tamodulecheckins") }}">
+            <div id="checkinsModule" class="col-lg-10 tab-pane fade" data-target="{{ route("tamodulecheckins") }}">
                 @include('ta.core.loading')
             </div>
-            <div id="secretWordPanel" class="col-lg-10 tab-pane fade" data-target="{{ route("tamodulesecretword") }}">
+            <div id="secretWordModule" class="col-lg-10 tab-pane fade" data-target="{{ route("tamodulesecretword") }}">
                 @include('ta.core.loading')
             </div>
-            <div id="announcementsPanel" class="col-lg-10 tab-pane fade" data-target="{{ route("tamoduleannouncements") }}">
+            <div id="announcementsModule" class="col-lg-10 tab-pane fade" data-target="{{ route("tamoduleannouncements") }}">
                 @include('ta.core.loading')
             </div>
-            <div id="exportDataPanel" class="col-lg-10 tab-pane fade" data-target="{{ route("tamoduleexport") }}">
+            <div id="exportDataModule" class="col-lg-10 tab-pane fade" data-target="{{ route("tamoduleexport") }}">
                 @include('ta.core.loading')
             </div>
-            <div id="sectionPanel" class="col-lg-10 tab-pane fade" data-target="{{ route("tamodulesections") }}">
+            <div id="sectionsModule" class="col-lg-10 tab-pane fade" data-target="{{ route("tamodulesections") }}">
                 @include('ta.core.loading')
             </div>
-            <div id="statsPanel" class="col-lg-10 tab-pane fade" data-target="{{ route("tamodulestats") }}">
+            <div id="statsModule" class="col-lg-10 tab-pane fade" data-target="{{ route("tamodulestats") }}">
                 @include('ta.core.loading')
             </div>
             @if (Auth::user()->is_gsi())
-            <div id="eventTypesPanel" class="col-lg-10 tab-pane fade" data-target="{{ route("tamoduleeventtypes") }}">
+            <div id="eventTypesModule" class="col-lg-10 tab-pane fade" data-target="{{ route("tamoduleeventtypes") }}">
                 @include('ta.core.loading')
             </div>
-            <div id="auditLogPanel" class="col-lg-10 tab-pane fade" data-target="{{ route("tamoduleauditlog") }}">
+            <div id="auditLogModule" class="col-lg-10 tab-pane fade" data-target="{{ route("tamoduleauditlog") }}">
                 @include('ta.core.loading')
             </div>
-            <div id="settingsPanel" class="col-lg-10 tab-pane fade" data-target="{{ route("tamodulesettings") }}">
+            <div id="settingsModule" class="col-lg-10 tab-pane fade" data-target="{{ route("tamodulesettings") }}">
                 @include('ta.core.loading')
             </div>
             @endif
@@ -68,10 +68,14 @@
             tab.load(tab.attr('data-target'));
             tab.attr('loaded', 'true');
         }
+        history.pushState(null, '', tab.attr('id').slice(0, -6));
     }
 
     function init_tabs() {
-        show_tab($('.tab-pane.active'));
+        var activeTab = $('.tab-pane#{{{ $module }}}Module');
+        show_tab(activeTab);
+        activeTab.addClass('in active');
+        $('.nav-pills a[href=#{{{ $module }}}Module]').parents('li').addClass('active');
         $('a[data-toggle="pill"]').on('shown.bs.tab', function(e) {
             tab = $('#' + $(e.target).attr('href').substr(1));
             show_tab(tab);


### PR DESCRIPTION
Staff members can now visit specific modules in the TA Consoles via a URL. Forms posted from the TA Console now redirect back to the same module where the form was submitted.

Fixes #33, #129 