### PR TITLE
Update README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Provides a web-based interface for managing lab assistants. Allows TAs to config
         to: /home/vagrant/Code/Check-In
 
     sites:
-        - map: la.app
+        - map: la.local
         to: /home/vagrant/Code/Check-In/public
         php: "5.6"
     ```
@@ -84,12 +84,12 @@ Provides a web-based interface for managing lab assistants. Allows TAs to config
     You must add the "domains" for your Nginx sites to the hosts file on your machine. The hosts file will redirect requests for your Homestead sites into your Homestead machine. On Mac and Linux, this file is located at `/etc/hosts`. On Windows, it is located at `C:\Windows\System32\drivers\etc\hosts`. The lines you add to this file will look like the following:
 
     ```
-    192.168.10.10  la.app
+    192.168.10.10  la.local
     ```
 
     Make sure the IP address listed is the one set in your Homestead.yaml file. Once you have added the domain to your hosts file and launched the Vagrant box you will be able to access the site via your web browser:
 
-    http://la.app
+    http://la.local
 
 3. Set up environment variables
 
@@ -142,7 +142,7 @@ Provides a web-based interface for managing lab assistants. Allows TAs to config
 
 10. Write the codestuffs
 
-    Point your browser to http://la.app.
+    Point your browser to http://la.local.
 
     Edit files in `~/Projects/Check-In` as necessary
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,9 @@ Lab Assistant Manager
 
 ## Overview
 
-Provides a web-based interface for managing lab assistants. Allows TAs to configure seections for lab assistants to sign up for along with facilitating the check in process. 
+Provides a web-based interface for managing lab assistants. Allows TAs to configure seections for lab assistants to sign up for along with facilitating the check in process.
 
-
-## Branches Organization:
+## Branch Organization:
 * ***master*** - is the main branch, storing the current code all non-course specific features should be branched from.
 * ***cs61a*** - is the master branch for the CS61A course lab assistant manager instance.
 * ***cs61b*** - is the master branch for the CS61B course lab assistant manager instance.
@@ -24,30 +23,30 @@ Provides a web-based interface for managing lab assistants. Allows TAs to config
 
     Download and install virtual box:
     https://www.virtualbox.org/wiki/Downloads
- 
+
     Download and install vagrant:
     https://www.vagrantup.com/downloads.html
 
     Install the Homestead Vagrant Box:
     `vagrant box add laravel/homestead`
-    
+
     Install Homestead
-    
+
     ```
     cd ~
     git clone https://github.com/laravel/homestead.git Homestead
-    // Clone the desired release...
+    # Clone the desired release...
     git checkout v6.1.0
-    
-    // If on Mac / Linux...
+
+    # If on Mac / Linux...
     bash init.sh
 
-    // If on Windows...
+    # If on Windows...
     init.bat
     ```
-    
-    Update homestead.yaml to point to where you are cloning this repo. E.g:
-    
+
+    Update `Homestead.yaml` to point to where you are cloning this repo. E.g:
+
     ```
     folders:
         - map: ~/Projects/Check-In
@@ -58,8 +57,29 @@ Provides a web-based interface for managing lab assistants. Allows TAs to config
         to: /home/vagrant/Code/Check-In/public
         php: "5.6"
     ```
-    
-2. The Hosts File
+
+    Append the following lines to `after.sh`:
+
+    ```
+    # Install MySQL Server, PHP 5.6 and required packages
+    sudo apt update
+    sudo apt install -y mysql-server php5.6-common php5.6-cli php5.6-curl php5.6-fpm php5.6-mbstring php5.6-mcrypt php5.6-mysql php5.6-xml
+
+    # Use PHP5.6 as system default PHP
+    sudo update-alternatives --set php $(which php5.6)
+
+    # Change any PHP7 references in Nginx sites
+    sudo sed -i -E 's/php7[.0-9]*?/php5.6/g' /etc/nginx/sites-available/*
+
+    # Change PHP5.6 FPM to run under vagrant user (necessary for writing data to Check-In folder)
+    sudo sed -i -e 's/www-data/vagrant/g' /etc/php/5.6/fpm/pool.d/www.conf
+
+    # Reload config changes
+    sudo service nginx restart
+    sudo service php5.6-fpm restart
+    ```
+
+2. Set up your hosts file
 
     You must add the "domains" for your Nginx sites to the hosts file on your machine. The hosts file will redirect requests for your Homestead sites into your Homestead machine. On Mac and Linux, this file is located at `/etc/hosts`. On Windows, it is located at `C:\Windows\System32\drivers\etc\hosts`. The lines you add to this file will look like the following:
     ```
@@ -68,55 +88,73 @@ Provides a web-based interface for managing lab assistants. Allows TAs to config
     Make sure the IP address listed is the one set in your Homestead.yaml file. Once you have added the domain to your hosts file and launched the Vagrant box you will be able to access the site via your web browser:
 
     http://la.app
-3. Go to your Homestead directory. Bring up Vagrant
+
+3. Set up environment variables
+    ```
+    cd ~/Projects/Check-In
+    # Copy the example environment variable file to .env
+    cp env.example .env
+    # Edit .env as necessary
+    vim .env # or with your editor of choice
+    ```
+
+4. Start the Vagrant instance
 
     ```
     cd ~/Homestead
     vagrant up
     ```
-    
-4. SSH Into Vagrant Box
+
+5. SSH into the Vagrant instance
     ```
     vagrant ssh
-    // Set working directory to be project location
-    cd Code/Check-In
+    # Set working directory to project location
+    cd ~/Code/Check-In
     ```
-5. Via SSH install dependencies through the PHP package manager `composer`. 
+
+6. In SSH: Install dependencies using `composer` (PHP package manager)
 
     `composer install`
 
-6. Via SSH run the database migrations
+7. In SSH: Run the database migrations
 
     `php artisan migrate`
 
-7. Via SSH Seed the database with the proper first few values
+8. In SSH: Seed the database with initial values
 
     `php artisan db:seed --class DefaultSettingsSeeder`
 
-8. Set up environment variables
-    ```
-    // Copy the example environment variable file to .env
-    cp env.example .env
-    ```
-9. Via SSH generate an application key
+9. In SSH: Generate an application key
 
     `php artisan key:generate`
 
-10. Launch Vagrant:
+10. Write the codestuffs
+
+    Point your browser to http://la.app.
+
+    Edit files in `~/Projects/Check-In` as necessary
+
+11. Stop the VM when you're done working
+
+    `vagrant halt`
+
+## Post-Installation
+
+    The next time you want to start working again, simply start the Vagrant instance again
+
     `vagrant up`
-    
+
+    And stop it when you're done
+
+    `vagrant halt`
+
     If you change the sites or maps inside of `Homestead.yaml` you will need to run the following to update Vagrant:
     `vagrant reload --provision`
-    
-    
-
-11. Point your browser to http://la.app. 
-
 
 ## Deployment
 
 First point a git remote to the Dokku server (the example below is CS61A specific):
-    
+
     git remote add dokku dokku@app.cs61a.org:la
 
 To deploy from master:
@@ -126,7 +164,7 @@ To deploy from master:
 Deploy from another branch:
 
     git push dokku my_branch:master
-    
+
 
 ### First Time Deployment
 
@@ -148,12 +186,7 @@ Tip:  add `alias dokku="ssh -t dokku@app.cs61a.org"` to your aliases file (e.g. 
     MAIL_HOST=<MAIL_HOST> MAIL_PORT=<MAIL_PORT> MAIL_USERNAME=<MAIL_USERNAME> MAIL_PASSWORD=<MAIL_SECRET> MAIL_ENCRYPTION=null
     dokku letsencrypt app-name
     # Change OK OAuth to support the domain
-    
+
     # Run migrations after following steps in Deployment
     dokku enter <app_name> web php artisan migrate --force
     dokku enter <app_name> web php artisan db:seed --class=DefaultSettingsSeeder --force
-
-    
-
-
-

--- a/README.md
+++ b/README.md
@@ -140,16 +140,22 @@ Provides a web-based interface for managing lab assistants. Allows TAs to config
 
 ## Post-Installation
 
-    The next time you want to start working again, simply start the Vagrant instance again
+The next time you want to start working again, simply start the Vagrant instance again
 
-    `vagrant up`
+```
+vagrant up
+```
 
-    And stop it when you're done
+And stop it when you're done
 
-    `vagrant halt`
+```
+vagrant halt
+```
 
-    If you change the sites or maps inside of `Homestead.yaml` you will need to run the following to update Vagrant:
-    `vagrant reload --provision`
+If you change the sites or maps inside of `Homestead.yaml` you will need to run the following to update Vagrant:
+```
+vagrant reload --provision
+```
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -82,14 +82,17 @@ Provides a web-based interface for managing lab assistants. Allows TAs to config
 2. Set up your hosts file
 
     You must add the "domains" for your Nginx sites to the hosts file on your machine. The hosts file will redirect requests for your Homestead sites into your Homestead machine. On Mac and Linux, this file is located at `/etc/hosts`. On Windows, it is located at `C:\Windows\System32\drivers\etc\hosts`. The lines you add to this file will look like the following:
+
     ```
     192.168.10.10  la.app
     ```
+
     Make sure the IP address listed is the one set in your Homestead.yaml file. Once you have added the domain to your hosts file and launched the Vagrant box you will be able to access the site via your web browser:
 
     http://la.app
 
 3. Set up environment variables
+
     ```
     cd ~/Projects/Check-In
     # Copy the example environment variable file to .env
@@ -106,6 +109,7 @@ Provides a web-based interface for managing lab assistants. Allows TAs to config
     ```
 
 5. SSH into the Vagrant instance
+
     ```
     vagrant ssh
     # Set working directory to project location
@@ -114,19 +118,27 @@ Provides a web-based interface for managing lab assistants. Allows TAs to config
 
 6. In SSH: Install dependencies using `composer` (PHP package manager)
 
-    `composer install`
+    ```
+    composer install
+    ```
 
 7. In SSH: Run the database migrations
 
-    `php artisan migrate`
+    ```
+    php artisan migrate
+    ```
 
 8. In SSH: Seed the database with initial values
 
-    `php artisan db:seed --class DefaultSettingsSeeder`
+    ```
+    php artisan db:seed --class DefaultSettingsSeeder
+    ```
 
 9. In SSH: Generate an application key
 
-    `php artisan key:generate`
+    ```
+    php artisan key:generate
+    ```
 
 10. Write the codestuffs
 
@@ -136,7 +148,9 @@ Provides a web-based interface for managing lab assistants. Allows TAs to config
 
 11. Stop the VM when you're done working
 
-    `vagrant halt`
+    ```
+    vagrant halt
+    ```
 
 ## Post-Installation
 

--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ Provides a web-based interface for managing lab assistants. Allows TAs to config
     ```
     folders:
         - map: ~/Projects/Check-In
-        to: /home/vagrant/Code/Check-In
+          to: /home/vagrant/Code/Check-In
 
     sites:
         - map: la.local
-        to: /home/vagrant/Code/Check-In/public
-        php: "5.6"
+          to: /home/vagrant/Code/Check-In/public
+          php: "5.6"
     ```
 
     Append the following lines to `after.sh`:


### PR DESCRIPTION
Essentially every AI working on this app had to use modified instructions to get the app running on our laptops. This is an updated set of installation instructions that we tested to work.

PHP 5.6 no longer seems to be supported in recent Homestead versions, so we manually installed it.