### PR TITLE
Remove information about taking without units

### DIFF
--- a/resources/views/assignments.blade.php
+++ b/resources/views/assignments.blade.php
@@ -30,7 +30,7 @@
                     <input class="form-control" type="text" id="inputHours" name="inputHours" value="{{{ Auth::user()->hours }}}" placeholder="Ex: 3" />
                 </div>
                 <div class="form-group">
-                    <label for="inputUnits">Units <small>(Enter 0 if you are not lab assisting for units)</small></label>
+                    <label for="inputUnits">Units</label>
                     <input class="form-control" type="number" id="inputUnits" name="inputUnits" value="{{{ Auth::user()->units }}}" placeholder="Ex: 1" />
                 </div>
                 <hr />


### PR DESCRIPTION
There is no option now for lab assisting without units. Removing this line for clarity.